### PR TITLE
Material UI Cleanup

### DIFF
--- a/ContentEditor.App/Configuration/AppConfig.cs
+++ b/ContentEditor.App/Configuration/AppConfig.cs
@@ -82,6 +82,8 @@ public class AppConfig : Singleton<AppConfig>
 
         public const string Key_Undo = "key_undo";
         public const string Key_Redo = "key_redo";
+        public const string Key_Copy = "key_copy";
+        public const string Key_Paste = "key_paste";
         public const string Key_Save = "key_save";
         public const string Key_Open = "key_open";
         public const string Key_OpenPakBrowser = "key_open_pak_browser";
@@ -354,6 +356,8 @@ public class AppConfig : Singleton<AppConfig>
 
     public readonly SettingWrapper<KeyBinding> Key_Undo = new SettingWrapper<KeyBinding>(Keys.Key_Undo, _lock, new KeyBinding(ImGuiKey.Z, ctrl: true));
     public readonly SettingWrapper<KeyBinding> Key_Redo = new SettingWrapper<KeyBinding>(Keys.Key_Redo, _lock, new KeyBinding(ImGuiKey.Y, ctrl: true));
+    public readonly SettingWrapper<KeyBinding> Key_Copy = new SettingWrapper<KeyBinding>(Keys.Key_Copy, _lock, new KeyBinding(ImGuiKey.C, ctrl: true));
+    public readonly SettingWrapper<KeyBinding> Key_Paste = new SettingWrapper<KeyBinding>(Keys.Key_Paste, _lock, new KeyBinding(ImGuiKey.V, ctrl: true));
     public readonly SettingWrapper<KeyBinding> Key_Save = new SettingWrapper<KeyBinding>(Keys.Key_Save, _lock, new KeyBinding(ImGuiKey.S, ctrl: true));
     public readonly SettingWrapper<KeyBinding> Key_Open = new SettingWrapper<KeyBinding>(Keys.Key_Open, _lock, new KeyBinding(ImGuiKey.O, ctrl: true));
     public readonly SettingWrapper<KeyBinding> Key_OpenPakBrowser = new SettingWrapper<KeyBinding>(Keys.Key_OpenPakBrowser, _lock, new KeyBinding(ImGuiKey.B, ctrl: true));
@@ -541,6 +545,8 @@ public class AppConfig : Singleton<AppConfig>
 
             (Keys.Key_Undo, instance.Key_Undo.value.ToString(), "Keys"),
             (Keys.Key_Redo, instance.Key_Redo.value.ToString(), "Keys"),
+            (Keys.Key_Copy, instance.Key_Copy.value.ToString(), "Keys"),
+            (Keys.Key_Paste, instance.Key_Paste.value.ToString(), "Keys"),
             (Keys.Key_Save, instance.Key_Save.value.ToString(), "Keys"),
             (Keys.Key_Open, instance.Key_Open.value.ToString(), "Keys"),
             (Keys.Key_OpenPakBrowser, instance.Key_OpenPakBrowser.value.ToString(), "Keys"),
@@ -813,6 +819,8 @@ public class AppConfig : Singleton<AppConfig>
                     switch (key) {
                         case Keys.Key_Undo: if (KeyBinding.TryParse(value, out var _key)) Key_Undo.value = _key; break;
                         case Keys.Key_Redo: if (KeyBinding.TryParse(value, out _key)) Key_Redo.value = _key; break;
+                        case Keys.Key_Copy: if (KeyBinding.TryParse(value, out _key)) Key_Copy.value = _key; break;
+                        case Keys.Key_Paste: if (KeyBinding.TryParse(value, out _key)) Key_Paste.value = _key; break;
                         case Keys.Key_Save: if (KeyBinding.TryParse(value, out _key)) Key_Save.value = _key; break;
                         case Keys.Key_Open: if (KeyBinding.TryParse(value, out _key)) Key_Open.value = _key; break;
                         case Keys.Key_OpenPakBrowser: if (KeyBinding.TryParse(value, out _key)) Key_OpenPakBrowser.value = _key; break;

--- a/ContentEditor.App/Imgui/Editors/MdfEditor.cs
+++ b/ContentEditor.App/Imgui/Editors/MdfEditor.cs
@@ -256,9 +256,9 @@ public class MdfFileImguiHandler : IObjectUIHandler
         }
 
         ImGui.Separator();
-        var visibleMaterials = string.IsNullOrEmpty(materialSearch)
-            ? list
-            : list.Where(mat => mat.Header.matName.Contains(materialSearch, StringComparison.OrdinalIgnoreCase)).ToList();
+        var visibleMaterials = list
+            .Where(mat => string.IsNullOrEmpty(materialSearch) || mat.Header.matName.Contains(materialSearch, StringComparison.OrdinalIgnoreCase))
+            .ToList();
         foreach (var mat in visibleMaterials) {
             int i = list.IndexOf(mat);
 
@@ -294,7 +294,7 @@ public class MdfFileImguiHandler : IObjectUIHandler
         }
 
         var windowData = context.FindValueInParentValues<WindowData>();
-        if (windowData?.IsFocused == true && ImGui.IsWindowFocused() && !ImGui.GetIO().WantTextInput) {
+        if (windowData?.IsFocused == true && !ImGui.GetIO().WantTextInput) {
             if (CopyMaterialShortcut.IsPressed()) {
                 CopyMaterials(list.Where(selectedMaterials.Contains).ToList());
             }

--- a/ContentEditor.App/Imgui/Editors/MdfEditor.cs
+++ b/ContentEditor.App/Imgui/Editors/MdfEditor.cs
@@ -303,6 +303,11 @@ public class MdfFileImguiHandler : IObjectUIHandler
             }
         }
         ImGui.Separator();
+        if (ImGui.BeginPopupContextWindow("##MaterialListEmptyAreaMenu", ImGuiPopupFlags.MouseButtonRight | ImGuiPopupFlags.NoOpenOverItems)) {
+            var contextMaterial = list.FirstOrDefault(selectedMaterials.Contains) ?? list.ElementAtOrDefault(selectedIDX);
+            ShowMaterialContextMenu(context, list, contextMaterial);
+            ImGui.EndPopup();
+        }
 
         if (ImGui.BeginPopupModal("MdfTexExport")) {
             texExporter ??= new();
@@ -382,17 +387,19 @@ public class MdfFileImguiHandler : IObjectUIHandler
             ImGui.EndTabItem();
         }
     }
-    private void ShowMaterialContextMenu(UIContext context, List<MaterialData> list, MaterialData mat)
+    private void ShowMaterialContextMenu(UIContext context, List<MaterialData> list, MaterialData? mat)
     {
         var contextSelection = list.Where(selectedMaterials.Contains).ToList();
-        if (contextSelection.Count == 0) contextSelection.Add(mat);
+        if (contextSelection.Count == 0 && mat != null) contextSelection.Add(mat);
 
-        if (ImGui.MenuItem(Lang.Buttons.Duplicate)) {
-            var duplicates = DuplicateMaterials(context, list, contextSelection);
-            SelectMaterials(context, list, duplicates);
-        }
-        if (ImGui.MenuItem(Lang.Buttons.Copy)) {
-            CopyMaterials(contextSelection);
+        using (var _ = ImguiHelpers.Disabled(contextSelection.Count == 0)) {
+            if (ImGui.MenuItem(Lang.Buttons.Duplicate)) {
+                var duplicates = DuplicateMaterials(context, list, contextSelection);
+                SelectMaterials(context, list, duplicates);
+            }
+            if (ImGui.MenuItem(Lang.Buttons.Copy)) {
+                CopyMaterials(contextSelection);
+            }
         }
         using (var i = ImguiHelpers.Disabled(!HasMaterialsInClipboard())) {
             if (ImGui.MenuItem(Lang.Buttons.Paste)) {
@@ -400,11 +407,13 @@ public class MdfFileImguiHandler : IObjectUIHandler
             }
         }
         ImGui.Separator();
-        if (ImGui.MenuItem(Lang.Buttons.Delete)) {
-            int index = list.IndexOf(mat);
-            UndoRedo.RecordListRemove(context, list, mat);
-            int newIndex = list.Count == 0 ? -1 : Math.Clamp(index - 1, 0, list.Count - 1);
-            SelectOnlyMaterial(context, list, newIndex);
+        using (var _ = ImguiHelpers.Disabled(mat == null)) {
+            if (ImGui.MenuItem(Lang.Buttons.Delete)) {
+                int index = list.IndexOf(mat!);
+                UndoRedo.RecordListRemove(context, list, mat!);
+                int newIndex = list.Count == 0 ? -1 : Math.Clamp(index - 1, 0, list.Count - 1);
+                SelectOnlyMaterial(context, list, newIndex);
+            }
         }
     }
 

--- a/ContentEditor.App/Imgui/Editors/MdfEditor.cs
+++ b/ContentEditor.App/Imgui/Editors/MdfEditor.cs
@@ -175,8 +175,6 @@ public class MdfFileImguiHandler : IObjectUIHandler
     private bool isMaterialListWidthInitialized;
     private float materialListW = 250f; // SILVER: Maybe we should save this value?
     private float materialListMaxW = 500f;
-    private static readonly KeyBinding CopyMaterialShortcut = new(ImGuiKey.C, ctrl: true);
-    private static readonly KeyBinding PasteMaterialShortcut = new(ImGuiKey.V, ctrl: true);
 
     public void OnIMGUI(UIContext context)
     {
@@ -307,10 +305,10 @@ public class MdfFileImguiHandler : IObjectUIHandler
 
         var windowData = context.FindValueInParentValues<WindowData>();
         if (windowData?.IsFocused == true && !ImGui.GetIO().WantTextInput) {
-            if (CopyMaterialShortcut.IsPressed()) {
+            if (AppConfig.Instance.Key_Copy.Get().IsPressed()) {
                 CopyMaterials(list.Where(selectedMaterials.Contains).ToList());
             }
-            if (PasteMaterialShortcut.IsPressed()) {
+            if (AppConfig.Instance.Key_Paste.Get().IsPressed()) {
                 PasteMaterials(context, list, pasted => SelectMaterials(context, list, pasted));
             }
         }

--- a/ContentEditor.App/Imgui/Editors/MdfEditor.cs
+++ b/ContentEditor.App/Imgui/Editors/MdfEditor.cs
@@ -384,15 +384,15 @@ public class MdfFileImguiHandler : IObjectUIHandler
     }
     private void ShowMaterialContextMenu(UIContext context, List<MaterialData> list, MaterialData mat)
     {
+        var contextSelection = list.Where(selectedMaterials.Contains).ToList();
+        if (contextSelection.Count == 0) contextSelection.Add(mat);
+
         if (ImGui.MenuItem(Lang.Buttons.Duplicate)) {
-            var clone = mat.Clone();
-            clone.Name = $"{mat.Name}_copy".GetUniqueName(str => list.Any(l => l.Name == str));
-            clone.Header.matNameHash = MurMur3HashUtils.GetHash(clone.Name);
-            UndoRedo.RecordListAdd(context, list, clone);
-            SelectOnlyMaterial(context, list, list.Count - 1);
+            var duplicates = DuplicateMaterials(context, list, contextSelection);
+            SelectMaterials(context, list, duplicates);
         }
         if (ImGui.MenuItem(Lang.Buttons.Copy)) {
-            CopyMaterials(selectedMaterials.Contains(mat) ? list.Where(selectedMaterials.Contains).ToList() : [mat]);
+            CopyMaterials(contextSelection);
         }
         using (var i = ImguiHelpers.Disabled(!HasMaterialsInClipboard())) {
             if (ImGui.MenuItem(Lang.Buttons.Paste)) {
@@ -492,6 +492,20 @@ public class MdfFileImguiHandler : IObjectUIHandler
         }
     }
 
+    private static List<MaterialData> DuplicateMaterials(UIContext context, List<MaterialData> list, IReadOnlyList<MaterialData> materials)
+    {
+        var duplicates = new List<MaterialData>(materials.Count);
+        foreach (var material in materials) {
+            var clone = material.Clone();
+            clone.Name = $"{material.Name}_copy".GetUniqueName(str => list.Any(l => l.Name == str) || duplicates.Any(l => l.Name == str));
+            clone.Header.matNameHash = MurMur3HashUtils.GetHash(clone.Name);
+            duplicates.Add(clone);
+        }
+
+        AddMaterials(context, list, duplicates);
+        return duplicates;
+    }
+
     private static bool HasMaterialsInClipboard()
         => VirtualClipboard.TryGetFromClipboard<MaterialData>(out _) || VirtualClipboard.TryGetFromClipboard<MaterialClipboardData>(out _);
 
@@ -513,18 +527,23 @@ public class MdfFileImguiHandler : IObjectUIHandler
             clones.Add(clone);
         }
 
+        AddMaterials(context, list, clones);
+        onMaterialsPasted?.Invoke(clones);
+    }
+
+    private static void AddMaterials(UIContext context, List<MaterialData> list, List<MaterialData> materials)
+    {
         UndoRedo.RecordCallback(
             context,
             () => {
-                list.AddRange(clones);
+                list.AddRange(materials);
                 context.children.Clear();
             },
             () => {
-                foreach (var clone in clones) list.Remove(clone);
+                foreach (var material in materials) list.Remove(material);
                 context.children.Clear();
             }
         );
-        onMaterialsPasted?.Invoke(clones);
     }
 
     private sealed class MaterialClipboardData(MaterialData[] materials)

--- a/ContentEditor.App/Imgui/Editors/MdfEditor.cs
+++ b/ContentEditor.App/Imgui/Editors/MdfEditor.cs
@@ -172,20 +172,32 @@ public class MdfFileImguiHandler : IObjectUIHandler
     private readonly HashSet<MaterialData> selectedMaterials = [];
     private MaterialData? materialSelectionAnchor;
     private bool isMaterialSelectionInitialized;
+    private bool isMaterialListWidthInitialized;
     private float materialListW = 250f; // SILVER: Maybe we should save this value?
+    private float materialListMaxW = 500f;
     private static readonly KeyBinding CopyMaterialShortcut = new(ImGuiKey.C, ctrl: true);
     private static readonly KeyBinding PasteMaterialShortcut = new(ImGuiKey.V, ctrl: true);
 
     public void OnIMGUI(UIContext context)
     {
         var file = context.Get<MdfFile>();
+        if (!isMaterialListWidthInitialized) {
+            isMaterialListWidthInitialized = true;
+            var style = ImGui.GetStyle();
+            var longestNameWidth = file.Materials.Count == 0
+                ? 0f
+                : file.Materials.Max(material => ImGui.CalcTextSize(string.IsNullOrEmpty(material.Header.matName) ? "<missingName>" : material.Header.matName).X);
+            var labelPadding = style.WindowPadding.X * 2 + style.FramePadding.X * 2 + style.ItemSpacing.X * 2 + style.ScrollbarSize;
+            materialListW = MathF.Max(materialListW, longestNameWidth + labelPadding);
+            materialListMaxW = MathF.Max(materialListMaxW, materialListW);
+        }
 
         ImGui.BeginChild("##MaterialList", new Vector2(materialListW, ImGui.GetContentRegionAvail().Y));
         ShowMaterialList(context, file);
         ImGui.EndChild();
 
         ImGui.SameLine();
-        ImguiHelpers.VerticalSplitter(ref materialListW, 100, 500, 2, 2, ImGui.GetContentRegionAvail().Y);
+        ImguiHelpers.VerticalSplitter(ref materialListW, 100, materialListMaxW, 2, 2, ImGui.GetContentRegionAvail().Y);
         ImGui.SameLine();
 
         ImGui.BeginChild("##MaterialData", new Vector2(ImGui.GetContentRegionAvail().X, ImGui.GetContentRegionAvail().Y));

--- a/ContentEditor.App/Imgui/Editors/MdfEditor.cs
+++ b/ContentEditor.App/Imgui/Editors/MdfEditor.cs
@@ -169,6 +169,9 @@ public class MdfFileImguiHandler : IObjectUIHandler
     private string matParamSearchQuery = string.Empty;
     private bool isMatParamMatchCase = false;
     private MaterialData? draggedMat;
+    private readonly HashSet<MaterialData> selectedMaterials = [];
+    private MaterialData? materialSelectionAnchor;
+    private bool isMaterialSelectionInitialized;
     private float materialListW = 250f; // SILVER: Maybe we should save this value?
     private static readonly KeyBinding CopyMaterialShortcut = new(ImGuiKey.C, ctrl: true);
     private static readonly KeyBinding PasteMaterialShortcut = new(ImGuiKey.V, ctrl: true);
@@ -192,15 +195,16 @@ public class MdfFileImguiHandler : IObjectUIHandler
     private unsafe void ShowMaterialList(UIContext context, MdfFile file)
     {
         var list = file.Materials;
+        SyncMaterialSelection(list);
 
         ImGui.TextColored(Colors.Faded, "Material List");
         ImGui.Separator();
         ImguiHelpers.ToggleButtonMultiColor(AppIcons.SIC_MaterialAdd, ref isNewMaterialMenu, new[] { Colors.IconPrimary, Colors.IconSecondary }, Colors.IconActive);
         ImguiHelpers.Tooltip("Add new Material");
         ImGui.SameLine();
-        using (var __ = ImguiHelpers.Disabled(!VirtualClipboard.TryGetFromClipboard<MaterialData>(out _))) {
+        using (var __ = ImguiHelpers.Disabled(!HasMaterialsInClipboard())) {
             if (ImguiHelpers.ButtonMultiColor(AppIcons.SIC_MaterialPaste, new[] {Colors.IconPrimary, Colors.IconPrimary, Colors.IconSecondary})) {
-                PasteMaterial(context, list, SelectMaterial);
+                PasteMaterials(context, list, pasted => SelectMaterials(context, list, pasted));
             }
             ImguiHelpers.Tooltip("Paste Material from clipboard");
         }
@@ -235,8 +239,7 @@ public class MdfFileImguiHandler : IObjectUIHandler
                     if (ImGui.Button($"{AppIcons.SI_GenericAdd}")) {
                         var mat = new MaterialData(new MaterialHeader { matName = newMaterialName });
                         UndoRedo.RecordListAdd(context, list, mat);
-                        selectedIDX = list.Count - 1;
-                        context.children.Clear();
+                        SelectOnlyMaterial(context, list, list.Count - 1);
                         newMaterialName = "";
                     }
                     ImGui.PopStyleColor();
@@ -253,16 +256,16 @@ public class MdfFileImguiHandler : IObjectUIHandler
         }
 
         ImGui.Separator();
-        for (int i = 0; i < list.Count; i++) {
-            var mat = list[i];
-            if (!string.IsNullOrEmpty(materialSearch) && !mat.Header.matName.Contains(materialSearch, StringComparison.OrdinalIgnoreCase)) {
-                continue;
-            }
+        var visibleMaterials = string.IsNullOrEmpty(materialSearch)
+            ? list
+            : list.Where(mat => mat.Header.matName.Contains(materialSearch, StringComparison.OrdinalIgnoreCase)).ToList();
+        foreach (var mat in visibleMaterials) {
+            int i = list.IndexOf(mat);
 
-            bool selected = i == selectedIDX;
+            bool selected = selectedMaterials.Contains(mat);
             ImGui.PushStyleColor(ImGuiCol.Text, selected ? Colors.TextActive : ImguiHelpers.GetColor(ImGuiCol.Text));
             if (ImGui.Selectable(string.IsNullOrEmpty(mat.Header.matName) ? "<missingName>##"+i : mat.Header.matName, selected)) {
-                selectedIDX = i;
+                UpdateMaterialSelection(list, visibleMaterials, mat, i);
                 context.children.Clear();
             }
             ImGui.PopStyleColor();
@@ -276,27 +279,27 @@ public class MdfFileImguiHandler : IObjectUIHandler
                 var payload = ImGui.GetDragDropPayload();
                 if (payload.Handle != null && payload.IsDataType("MDF_MATERIAL")) {
                     if (draggedMat != null && mat != draggedMat && ImGui.AcceptDragDropPayload("MDF_MATERIAL").Handle != null) {
-                        if (selectedIDX == list.IndexOf(draggedMat)) {
-                            selectedIDX = i;
-                        }
+                        var activeMaterial = list.ElementAtOrDefault(selectedIDX);
                         UndoRedo.RecordListMove(context, context, list, draggedMat, list, mat);
+                        selectedIDX = activeMaterial == null ? -1 : list.IndexOf(activeMaterial);
                     }
                 }
                 ImGui.EndDragDropTarget();
             }
 
             if (ImGui.BeginPopupContextItem($"##MaterialID{i}")) {
-                ShowMaterialContextMenu(context,file.Materials, mat, newIndex => { selectedIDX = newIndex;  context.children.Clear(); });
+                ShowMaterialContextMenu(context, list, mat);
                 ImGui.EndPopup();
             }
         }
 
-        if (ImGui.IsWindowFocused() && !ImGui.GetIO().WantTextInput) {
-            if (CopyMaterialShortcut.IsPressed() && list.ElementAtOrDefault(selectedIDX) is MaterialData selectedMaterial) {
-                CopyMaterial(selectedMaterial);
+        var windowData = context.FindValueInParentValues<WindowData>();
+        if (windowData?.IsFocused == true && ImGui.IsWindowFocused() && !ImGui.GetIO().WantTextInput) {
+            if (CopyMaterialShortcut.IsPressed()) {
+                CopyMaterials(list.Where(selectedMaterials.Contains).ToList());
             }
             if (PasteMaterialShortcut.IsPressed()) {
-                PasteMaterial(context, list, SelectMaterial);
+                PasteMaterials(context, list, pasted => SelectMaterials(context, list, pasted));
             }
         }
         ImGui.Separator();
@@ -307,12 +310,6 @@ public class MdfFileImguiHandler : IObjectUIHandler
                 ImGui.CloseCurrentPopup();
             }
             ImGui.EndPopup();
-        }
-
-        void SelectMaterial(int newIndex)
-        {
-            selectedIDX = newIndex;
-            context.children.Clear();
         }
     }
 
@@ -385,21 +382,21 @@ public class MdfFileImguiHandler : IObjectUIHandler
             ImGui.EndTabItem();
         }
     }
-    private static void ShowMaterialContextMenu(UIContext context, List<MaterialData> list, MaterialData mat, Action<int>? onSelectIndexChanged = null)
+    private void ShowMaterialContextMenu(UIContext context, List<MaterialData> list, MaterialData mat)
     {
         if (ImGui.MenuItem(Lang.Buttons.Duplicate)) {
             var clone = mat.Clone();
             clone.Name = $"{mat.Name}_copy".GetUniqueName(str => list.Any(l => l.Name == str));
             clone.Header.matNameHash = MurMur3HashUtils.GetHash(clone.Name);
             UndoRedo.RecordListAdd(context, list, clone);
-            onSelectIndexChanged?.Invoke(list.Count - 1);
+            SelectOnlyMaterial(context, list, list.Count - 1);
         }
         if (ImGui.MenuItem(Lang.Buttons.Copy)) {
-            CopyMaterial(mat);
+            CopyMaterials(selectedMaterials.Contains(mat) ? list.Where(selectedMaterials.Contains).ToList() : [mat]);
         }
-        using (var i = ImguiHelpers.Disabled(!VirtualClipboard.TryGetFromClipboard<MaterialData>(out _))) {
+        using (var i = ImguiHelpers.Disabled(!HasMaterialsInClipboard())) {
             if (ImGui.MenuItem(Lang.Buttons.Paste)) {
-                PasteMaterial(context, list, onSelectIndexChanged);
+                PasteMaterials(context, list, pasted => SelectMaterials(context, list, pasted));
             }
         }
         ImGui.Separator();
@@ -407,23 +404,134 @@ public class MdfFileImguiHandler : IObjectUIHandler
             int index = list.IndexOf(mat);
             UndoRedo.RecordListRemove(context, list, mat);
             int newIndex = list.Count == 0 ? -1 : Math.Clamp(index - 1, 0, list.Count - 1);
-            onSelectIndexChanged?.Invoke(newIndex);
+            SelectOnlyMaterial(context, list, newIndex);
         }
     }
 
-    private static void CopyMaterial(MaterialData material)
+    private void SyncMaterialSelection(List<MaterialData> list)
     {
-        VirtualClipboard.CopyToClipboard(material.Clone());
+        selectedMaterials.RemoveWhere(material => !list.Contains(material));
+        if (materialSelectionAnchor != null && !list.Contains(materialSelectionAnchor)) {
+            materialSelectionAnchor = null;
+        }
+
+        if (!isMaterialSelectionInitialized) {
+            isMaterialSelectionInitialized = true;
+            if (list.ElementAtOrDefault(selectedIDX) is MaterialData material) {
+                selectedMaterials.Add(material);
+                materialSelectionAnchor = material;
+            }
+        }
+
+        if (selectedIDX >= list.Count) {
+            selectedIDX = list.Count - 1;
+        }
     }
 
-    private static void PasteMaterial(UIContext context, List<MaterialData> list, Action<int>? onSelectIndexChanged)
+    private void UpdateMaterialSelection(List<MaterialData> list, List<MaterialData> visibleMaterials, MaterialData material, int materialIndex)
     {
-        if (!VirtualClipboard.TryGetFromClipboard<MaterialData>(out var pasted)) return;
+        bool isCtrlDown = ImGui.IsKeyDown(ImGuiKey.ModCtrl);
+        bool isShiftDown = ImGui.IsKeyDown(ImGuiKey.ModShift);
 
-        var clone = pasted.Clone();
-        clone.Header.matName = clone.Header.matName.GetUniqueName(str => list.Any(l => l.Header.matName == str));
-        UndoRedo.RecordListAdd(context, list, clone);
-        onSelectIndexChanged?.Invoke(list.Count - 1);
+        if (isShiftDown) {
+            int anchorIndex = materialSelectionAnchor == null ? -1 : visibleMaterials.IndexOf(materialSelectionAnchor);
+            if (anchorIndex == -1) {
+                anchorIndex = visibleMaterials.IndexOf(list.ElementAtOrDefault(selectedIDX)!);
+            }
+            if (anchorIndex == -1) {
+                anchorIndex = visibleMaterials.IndexOf(material);
+            }
+
+            if (!isCtrlDown) selectedMaterials.Clear();
+            int clickedIndex = visibleMaterials.IndexOf(material);
+            for (int i = Math.Min(anchorIndex, clickedIndex); i <= Math.Max(anchorIndex, clickedIndex); i++) {
+                selectedMaterials.Add(visibleMaterials[i]);
+            }
+        } else if (isCtrlDown) {
+            if (!selectedMaterials.Add(material)) {
+                selectedMaterials.Remove(material);
+            }
+            materialSelectionAnchor = material;
+        } else {
+            selectedMaterials.Clear();
+            selectedMaterials.Add(material);
+            materialSelectionAnchor = material;
+        }
+
+        selectedIDX = materialIndex;
+    }
+
+    private void SelectOnlyMaterial(UIContext context, List<MaterialData> list, int index)
+    {
+        selectedMaterials.Clear();
+        selectedIDX = index;
+        materialSelectionAnchor = list.ElementAtOrDefault(index);
+        if (materialSelectionAnchor != null) {
+            selectedMaterials.Add(materialSelectionAnchor);
+        }
+        context.children.Clear();
+    }
+
+    private void SelectMaterials(UIContext context, List<MaterialData> list, IReadOnlyList<MaterialData> materials)
+    {
+        selectedMaterials.Clear();
+        selectedMaterials.UnionWith(materials);
+        materialSelectionAnchor = materials.LastOrDefault();
+        selectedIDX = materialSelectionAnchor == null ? -1 : list.IndexOf(materialSelectionAnchor);
+        context.children.Clear();
+    }
+
+    private static void CopyMaterials(IReadOnlyList<MaterialData> materials)
+    {
+        if (materials.Count == 0) return;
+
+        if (materials.Count == 1) {
+            VirtualClipboard.CopyToClipboard(materials[0].Clone());
+        } else {
+            VirtualClipboard.CopyToClipboard(new MaterialClipboardData(materials.Select(material => material.Clone()).ToArray()));
+        }
+    }
+
+    private static bool HasMaterialsInClipboard()
+        => VirtualClipboard.TryGetFromClipboard<MaterialData>(out _) || VirtualClipboard.TryGetFromClipboard<MaterialClipboardData>(out _);
+
+    private static void PasteMaterials(UIContext context, List<MaterialData> list, Action<IReadOnlyList<MaterialData>>? onMaterialsPasted)
+    {
+        IReadOnlyList<MaterialData> pasted;
+        if (VirtualClipboard.TryGetFromClipboard<MaterialData>(out var singleMaterial)) {
+            pasted = [singleMaterial];
+        } else if (VirtualClipboard.TryGetFromClipboard<MaterialClipboardData>(out var materialClipboard)) {
+            pasted = materialClipboard.Materials;
+        } else {
+            return;
+        }
+
+        var clones = new List<MaterialData>(pasted.Count);
+        foreach (var material in pasted) {
+            var clone = material.Clone();
+            clone.Header.matName = clone.Header.matName.GetUniqueName(str => list.Any(l => l.Header.matName == str) || clones.Any(l => l.Header.matName == str));
+            clones.Add(clone);
+        }
+
+        UndoRedo.RecordCallback(
+            context,
+            () => {
+                list.AddRange(clones);
+                context.children.Clear();
+            },
+            () => {
+                foreach (var clone in clones) list.Remove(clone);
+                context.children.Clear();
+            }
+        );
+        onMaterialsPasted?.Invoke(clones);
+    }
+
+    private sealed class MaterialClipboardData(MaterialData[] materials)
+    {
+        public MaterialData[] Materials { get; } = materials;
+
+        public override string ToString() => $"{Materials.Length} materials";
     }
 
     private void ShowMaterialParameterToolbar(UIContext context)

--- a/ContentEditor.App/Imgui/Editors/MdfEditor.cs
+++ b/ContentEditor.App/Imgui/Editors/MdfEditor.cs
@@ -170,6 +170,8 @@ public class MdfFileImguiHandler : IObjectUIHandler
     private bool isMatParamMatchCase = false;
     private MaterialData? draggedMat;
     private float materialListW = 250f; // SILVER: Maybe we should save this value?
+    private static readonly KeyBinding CopyMaterialShortcut = new(ImGuiKey.C, ctrl: true);
+    private static readonly KeyBinding PasteMaterialShortcut = new(ImGuiKey.V, ctrl: true);
 
     public void OnIMGUI(UIContext context)
     {
@@ -198,13 +200,7 @@ public class MdfFileImguiHandler : IObjectUIHandler
         ImGui.SameLine();
         using (var __ = ImguiHelpers.Disabled(!VirtualClipboard.TryGetFromClipboard<MaterialData>(out _))) {
             if (ImguiHelpers.ButtonMultiColor(AppIcons.SIC_MaterialPaste, new[] {Colors.IconPrimary, Colors.IconPrimary, Colors.IconSecondary})) {
-                if (VirtualClipboard.TryGetFromClipboard<MaterialData>(out var pasted)) {
-                    var clone = pasted.Clone();
-                    clone.Header.matName = clone.Header.matName.GetUniqueName(str => list.Any(l => l.Header.matName == str));
-                    UndoRedo.RecordListAdd(context, list, clone);
-                    selectedIDX = list.Count - 1;
-                    context.children.Clear();
-                }
+                PasteMaterial(context, list, SelectMaterial);
             }
             ImguiHelpers.Tooltip("Paste Material from clipboard");
         }
@@ -294,6 +290,15 @@ public class MdfFileImguiHandler : IObjectUIHandler
                 ImGui.EndPopup();
             }
         }
+
+        if (ImGui.IsWindowFocused() && !ImGui.GetIO().WantTextInput) {
+            if (CopyMaterialShortcut.IsPressed() && list.ElementAtOrDefault(selectedIDX) is MaterialData selectedMaterial) {
+                CopyMaterial(selectedMaterial);
+            }
+            if (PasteMaterialShortcut.IsPressed()) {
+                PasteMaterial(context, list, SelectMaterial);
+            }
+        }
         ImGui.Separator();
 
         if (ImGui.BeginPopupModal("MdfTexExport")) {
@@ -302,6 +307,12 @@ public class MdfFileImguiHandler : IObjectUIHandler
                 ImGui.CloseCurrentPopup();
             }
             ImGui.EndPopup();
+        }
+
+        void SelectMaterial(int newIndex)
+        {
+            selectedIDX = newIndex;
+            context.children.Clear();
         }
     }
 
@@ -384,16 +395,11 @@ public class MdfFileImguiHandler : IObjectUIHandler
             onSelectIndexChanged?.Invoke(list.Count - 1);
         }
         if (ImGui.MenuItem(Lang.Buttons.Copy)) {
-            VirtualClipboard.CopyToClipboard(mat.Clone());
+            CopyMaterial(mat);
         }
         using (var i = ImguiHelpers.Disabled(!VirtualClipboard.TryGetFromClipboard<MaterialData>(out _))) {
             if (ImGui.MenuItem(Lang.Buttons.Paste)) {
-                if (VirtualClipboard.TryGetFromClipboard<MaterialData>(out var pasted)) {
-                    var clone = pasted.Clone();
-                    clone.Header.matName = clone.Header.matName.GetUniqueName(str => list.Any(l => l.Header.matName == str));
-                    UndoRedo.RecordListAdd(context, list, clone);
-                    onSelectIndexChanged?.Invoke(list.Count - 1);
-                }
+                PasteMaterial(context, list, onSelectIndexChanged);
             }
         }
         ImGui.Separator();
@@ -404,6 +410,22 @@ public class MdfFileImguiHandler : IObjectUIHandler
             onSelectIndexChanged?.Invoke(newIndex);
         }
     }
+
+    private static void CopyMaterial(MaterialData material)
+    {
+        VirtualClipboard.CopyToClipboard(material.Clone());
+    }
+
+    private static void PasteMaterial(UIContext context, List<MaterialData> list, Action<int>? onSelectIndexChanged)
+    {
+        if (!VirtualClipboard.TryGetFromClipboard<MaterialData>(out var pasted)) return;
+
+        var clone = pasted.Clone();
+        clone.Header.matName = clone.Header.matName.GetUniqueName(str => list.Any(l => l.Header.matName == str));
+        UndoRedo.RecordListAdd(context, list, clone);
+        onSelectIndexChanged?.Invoke(list.Count - 1);
+    }
+
     private void ShowMaterialParameterToolbar(UIContext context)
     {
         var workspace = context.GetWorkspace()!;

--- a/ContentEditor.App/Imgui/Editors/MdfEditor.cs
+++ b/ContentEditor.App/Imgui/Editors/MdfEditor.cs
@@ -467,7 +467,7 @@ public class MdfFileImguiHandler : IObjectUIHandler
             if (showOnlyBookmarked && !bookmarks!.IsBookmarked(workspace.Game.name, param.paramName)) {
                 continue;
             }
-            DrawMaterialParam(context, param, param.paramName);
+            DrawMaterialParam(context, param, param.paramName, mat.Parameters.IndexOf(param));
         }
 
         if (isGroupedParams && singles.Count > 0 && groups.Count > 0) {
@@ -486,7 +486,7 @@ public class MdfFileImguiHandler : IObjectUIHandler
                     if (idx >= 0 && idx < shortName.Length) {
                         shortName = shortName.Substring(idx + 1);
                     }
-                    DrawMaterialParam(context, param, shortName);
+                    DrawMaterialParam(context, param, shortName, mat.Parameters.IndexOf(param));
                 }
                 ImGui.TreePop();
             }
@@ -519,9 +519,10 @@ public class MdfFileImguiHandler : IObjectUIHandler
         return (singles, groups);
     }
 
-    private void DrawMaterialParam(UIContext parent, ParamHeader param, string label)
+    private void DrawMaterialParam(UIContext parent, ParamHeader param, string label, int index)
     {
         ImGui.PushID(param.paramName);
+        label = $"{label} [{index}]";
         var ctx = parent.GetChild(label) ?? parent.AddChild(label, param);
         ctx.uiHandler ??= new ParamHeaderImguiHandler();
         ctx.uiHandler.OnIMGUI(ctx);

--- a/ContentEditor.App/Imgui/SettingsWindowHandler.cs
+++ b/ContentEditor.App/Imgui/SettingsWindowHandler.cs
@@ -386,6 +386,8 @@ public class SettingsWindowHandler : IWindowHandler, IKeepEnabledWhileSaving
         ImguiKeybinding(Lang.Settings.Bind_Redo, config.Key_Redo);
         if (config.Key_Redo.Get().Key != ImGuiKey.Y) ImGui.TextColored(Colors.Warning, Lang.Settings.Warn_UndoRedoBinding);
 
+        ImguiKeybinding(Lang.Settings.Bind_Copy, config.Key_Copy);
+        ImguiKeybinding(Lang.Settings.Bind_Paste, config.Key_Paste);
         ImguiKeybinding(Lang.Settings.Bind_Save, config.Key_Save);
         ImguiKeybinding(Lang.Settings.Bind_Open, config.Key_Open);
         ImguiKeybinding(Lang.Settings.Bind_Close, config.Key_Close);

--- a/ContentEditor.App/Imgui/i18n/Translations/Settings.Lang.cs
+++ b/ContentEditor.App/Imgui/i18n/Translations/Settings.Lang.cs
@@ -125,6 +125,8 @@ public static partial class Lang
 
         public static readonly FixedString Bind_Undo = "Undo";
         public static readonly FixedString Bind_Redo = "Redo";
+        public static readonly FixedString Bind_Copy = "Copy";
+        public static readonly FixedString Bind_Paste = "Paste";
         public static readonly FixedString Bind_Save = "Save Open Files";
         public static readonly FixedString Bind_Open = "Open File";
         public static readonly FixedString Bind_Back = "Back";


### PR DESCRIPTION
-Add Mat Param Indices To UI
-Add Ctrl + C/V Copy/Paste Shortcuts For Materail List
-Bug Fix for Material Tab Content
-Material Lists Copy, Paste, Duplicate Context Menu Fixes
-Make Functionality of Unused Material List UI Space for Right Click Context
-Remove Material List Material Name Truncation With Higher Font Sizes